### PR TITLE
fix gowiki link

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -43,7 +43,7 @@ mkdir $HOME/go
 export GOPATH=$HOME/go
 ```
 
-In depth details on `GOPATH can be found [https://code.google.com/p/go-wiki/wiki/GOPATH](here).
+In depth details on `GOPATH can be found on the [go-wiki GOPATH page](https://code.google.com/p/go-wiki/wiki/GOPATH).
 
 ## GOPATH on  Windows
 


### PR DESCRIPTION
the link and text label were mixed up.  
I also gave the label a name that indicates where the link goes
which I think is nice for orienting the reader